### PR TITLE
Fix: Use host.docker.internal for Kafka advertised listeners

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     environment:
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
       # Host IP is automatically configured by start.sh
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://192.168.1.100:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://host.docker.internal:9092
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     depends_on:
       zookeeper:
@@ -37,7 +37,7 @@ services:
     ports:
       - "8083:8083"
     environment:
-      CONNECT_BOOTSTRAP_SERVERS: "192.168.1.100:9092"
+      CONNECT_BOOTSTRAP_SERVERS: "host.docker.internal:9092"
       CONNECT_REST_ADVERTISED_HOST_NAME: kafka-connect
       CONNECT_GROUP_ID: "kafka-connect-group"
       CONNECT_CONFIG_STORAGE_TOPIC: "connect-configs"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -2,19 +2,6 @@
 
 set -e  # Exit on error
 
-# Get host IP address (for macOS)
-HOST_IP=$(ifconfig | grep "inet " | grep -v 127.0.0.1 | awk '{print $2}' | head -n1)
-if [ -z "$HOST_IP" ]; then
-    echo "Failed to get host IP ✗"
-    exit 1
-fi
-
-# Update docker-compose.yml with host IP
-echo "Configuring Kafka advertised listeners with host IP: $HOST_IP"
-sed -i.bak "s/KAFKA_ADVERTISED_LISTENERS: PLAINTEXT:\/\/[0-9.]*:9092/KAFKA_ADVERTISED_LISTENERS: PLAINTEXT:\/\/$HOST_IP:9092/" docker-compose.yml
-sed -i.bak "s/CONNECT_BOOTSTRAP_SERVERS: \"[0-9.]*:9092\"/CONNECT_BOOTSTRAP_SERVERS: \"$HOST_IP:9092\"/" docker-compose.yml
-rm docker-compose.yml.bak
-
 echo "Starting services..."
 docker-compose up -d
 


### PR DESCRIPTION
I replaced hardcoded IP addresses in docker-compose.yml with 'host.docker.internal' for KAFKA_ADVERTISED_LISTENERS and CONNECT_BOOTSTRAP_SERVERS. This makes the configuration more portable and less reliant on environment-specific IP detection.

I removed the dynamic IP detection and substitution logic from the 'scripts/start.sh' script, as it is no longer needed.

Note: I could not complete the testing of these changes in the automated environment due to insufficient disk space for downloading the required Docker images. Manual verification in an environment with Docker and sufficient disk space is recommended.